### PR TITLE
[Fix] Further Updates For ORCiD [CAS-29]

### DIFF
--- a/framework/auth/campaigns.py
+++ b/framework/auth/campaigns.py
@@ -57,7 +57,7 @@ def get_campaigns():
                 template = 'branded'
                 name = provider.name
                 url_path = 'preprints/{}'.format(provider._id)
-                external_url = provider.get_provider_domain()
+                external_url = provider.get_provider_external_domain()
             campaign = '{}-preprints'.format(provider._id)
             system_tag = '{}_preprints'.format(provider._id)
             CAMPAIGNS.update({
@@ -127,13 +127,35 @@ def get_service_provider(campaign):
 
 
 def campaign_url_for(campaign):
+    """
+    Return the campaign's URL on OSF domain.
+
+    :param campaign: the campaign
+    :return: the url
+    """
     campaigns = get_campaigns()
     if campaign in campaigns:
         return campaigns.get(campaign).get('redirect_url')
     return None
 
 
+def external_campaign_url_for(campaign):
+    """
+    Return the campaign's URL on Non-OSF domain, which is available for phase 2 branded preprints only.
+
+    :param campaign: the campaign
+    :return: the external url if the campaign is hosted on Non-OSF domain, None otherwise
+    """
+    campaigns = get_campaigns()
+    if campaign in campaigns:
+        return campaigns.get(campaign).get('external_url')
+    return None
+
+
 def get_external_domains():
+    """
+    Return a list of trusted external domains for all eligible campaigns.
+    """
     campaigns = get_campaigns()
     external_domains = []
     for campaign, config in campaigns.items():

--- a/osf/models/preprint_provider.py
+++ b/osf/models/preprint_provider.py
@@ -81,10 +81,12 @@ class PreprintProvider(ObjectIDMixin, BaseModel):
         else:
             return None
 
-    if settings.DEV_MODE:
-        def get_provider_domain(self):
+    def get_provider_external_domain(self):
+        """
+        Return the provider's external domain.
+        """
+        if settings.DEV_MODE:
             domain_settings = settings.PREPRINT_PROVIDER_DOMAINS
-            return ''.join((domain_settings['prefix'], str(self.domain), domain_settings['suffix']))
-    else:
-        def get_provider_domain(self):
-            return settings.PROTOCOL + self.domain
+            return ''.join((domain_settings['prefix'], str(self.domain), domain_settings['suffix'], '/'))
+        else:
+            return settings.PROTOCOL + self.domain + '/'

--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -93,8 +93,8 @@ def main(env):
             'logo_name': 'engrxiv-logo.png',
             'description': 'The open archive of engineering.',
             'banner_name': 'engrxiv-banner.png',
-            'domain': 'engrxiv.org',
-            'external_url': 'http://engrxiv.org',
+            'domain': 'engrxiv.com',
+            'external_url': 'http://engrxiv.com',
             'example': 'k7fgk',
             'advisory_board': '''
                 <div class="col-xs-12">
@@ -236,8 +236,8 @@ def main(env):
             'logo_name': 'psyarxiv-logo.png',
             'description': 'A free preprint service for the psychological sciences.',
             'banner_name': 'psyarxiv-banner.png',
-            'domain': 'psyarxiv.com',
-            'external_url': 'http://psyarxiv.com',
+            'domain': 'psyarxiv.org',
+            'external_url': 'http://psyarxiv.org',
             'example': 'k9mn3',
             'advisory_board': '''
                 <div class="col-xs-12">

--- a/website/templates/public/register.mako
+++ b/website/templates/public/register.mako
@@ -72,7 +72,7 @@
                 %elif campaign == "psyarxiv-preprints":
                     <table style="border-collapse: separate; border-spacing: 30px 0; margin-top: 20px;  margin-bottom: 10px;">
                         <tr>
-                            <td><img src="/static/img/preprint_providers/psyarxiv-login.png" style="width: 150px; background: #caebf2; padding: 0 10px 0 10px;" /></td>
+                            <td><img src="/static/img/preprint_providers/psyarxiv-login.png" style="width: 150px; background: #062F4F; padding: 0 10px 0 10px;" /></td>
                             <td><h3>Create a free OSF account to contribute to PsyArXiv</h3></td>
                         </tr>
                     </table>


### PR DESCRIPTION
## Purpose

### ORCiD

Update ORCiD account creation/linking for external domains:

- during `external_login_email_post()`:
   service check regex matches both internal and external domain
- during `external_login_confirm_email_get()`:
   use external domain for destination if eligible

### Other

- enforce trailing slash for external domains
- update domains in population scripts to match ember-preprints login and logout url
- update logo background for PsyArxiv sign up page

## Ticket
https://openscience.atlassian.net/browse/CAS-29
